### PR TITLE
Erro de compilação input.asm:6: error: symbol `msg' not defined

### DIFF
--- a/input.asm
+++ b/input.asm
@@ -3,7 +3,7 @@
 section .data
 global main
     MSG: db 'Selecione uma letra/número', 10
-    LEN: equ $-msg
+    LEN: equ $-MSG
 
 section .bss
     %define BUFFER_INPUT 1


### PR DESCRIPTION
Admin:
- corrigi a definição de msg para MSG.